### PR TITLE
Bumped spellcheck action to latest version, since 0.24.0 is EOL

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -92,7 +92,7 @@ jobs:
         done
 
         echo "files=${files}" >> $GITHUB_ENV
-    - uses: rojopolis/spellcheck-github-actions@0.24.0
+    - uses: rojopolis/spellcheck-github-actions@0.35.0
       name: Spellcheck
       if: ${{ env.files }}
       with:


### PR DESCRIPTION
Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am sunsetting version 0.24.0 as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to version 0.35.0, so this PR offers an update to the latest version.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can see your are using [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, did you configure it for your account?

jonasbn